### PR TITLE
Removing mutually exclusivity for dirname and filename

### DIFF
--- a/command/args.go
+++ b/command/args.go
@@ -111,10 +111,6 @@ func validateOutputPaths(opts *Options) (bool, error) {
 		opts.OutputDir = wd
 	}
 
-	if opts.OutputFilename != "" && opts.OutputDir != "" {
-		return false, fmt.Errorf("dirname and filename are mutually exclusive")
-	}
-
 	if opts.OutputFilename != "" {
 		opts.OutputDir = path.Dir(opts.OutputFilename)
 		opts.OutputFilename = path.Base(opts.OutputFilename)


### PR DESCRIPTION
We would like to be able to not only determine a custom directory path and also give it custom filenames (namely, make them *_test.go so they get excluded by test coverage).